### PR TITLE
DEV: Refactor to use d-autocomplete and remove raw templates

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -5,16 +5,17 @@ import { getOwner } from "@ember/owner";
 import { cancel, next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { isPresent } from "@ember/utils";
-import $ from "jquery";
 import { emojiSearch, isSkinTonableEmoji } from "pretty-text/emoji";
 import { translations } from "pretty-text/emoji/data";
 import { Promise } from "rsvp";
 import EmojiPickerDetached from "discourse/components/emoji-picker/detached";
 import InsertHyperlink from "discourse/components/modal/insert-hyperlink";
-import { SKIP } from "discourse/lib/autocomplete";
-import { setupHashtagAutocomplete } from "discourse/lib/hashtag-autocomplete";
+import DAutocompleteModifier, { SKIP } from "discourse/modifiers/d-autocomplete";
+import { TextareaAutocompleteHandler } from "discourse/lib/textarea-text-manipulation";
+import { hashtagAutocompleteOptions } from "discourse/lib/hashtag-autocomplete";
+import renderEmojiAutocomplete from "discourse/lib/autocomplete/emoji";
+import userAutocomplete from "discourse/lib/autocomplete/user";
 import { cloneJSON } from "discourse/lib/object";
-import { findRawTemplate } from "discourse/lib/raw-templates";
 import { emojiUrlFor } from "discourse/lib/text";
 import userSearch from "discourse/lib/user-search";
 import {
@@ -82,10 +83,9 @@ export default class ChatComposer extends Component {
 
   @action
   setupAutocomplete(textarea) {
-    const $textarea = $(textarea);
-    this.#applyUserAutocomplete($textarea);
-    this.#applyEmojiAutocomplete($textarea);
-    this.#applyCategoryHashtagAutocomplete($textarea);
+    this.#applyUserAutocomplete(textarea);
+    this.#applyEmojiAutocomplete(textarea);
+    this.#applyCategoryHashtagAutocomplete(textarea);
   }
 
   @action
@@ -95,6 +95,16 @@ export default class ChatComposer extends Component {
     if (this.site.desktopView && this.args.autofocus) {
       this.composer.focus({ ensureAtEnd: true, refreshHeight: true });
     }
+  }
+  
+  applyAutocomplete(textarea, options) {
+    const autocompleteHandler = new TextareaAutocompleteHandler(textarea);
+    return DAutocompleteModifier.setupAutocomplete(
+      getOwner(this),
+      textarea,
+      autocompleteHandler,
+      options
+    );
   }
 
   @action
@@ -399,16 +409,17 @@ export default class ChatComposer extends Component {
     this.draft.mentionedUsers.set(user.id, user);
   }
 
-  #applyUserAutocomplete($textarea) {
+  #applyUserAutocomplete(textarea) {
     if (!this.siteSettings.enable_mentions) {
       return;
     }
 
-    $textarea.autocomplete({
-      template: findRawTemplate("user-selector-autocomplete"),
+    this.applyAutocomplete(textarea, {
+      template: userAutocomplete,
       key: "@",
       width: "100%",
       treatAsTextarea: true,
+      fixedTextareaPosition: true,
       autoSelectFirstSuggestion: true,
       transformComplete: (obj) => {
         if (obj.isUser) {
@@ -446,29 +457,32 @@ export default class ChatComposer extends Component {
     });
   }
 
-  #applyCategoryHashtagAutocomplete($textarea) {
-    setupHashtagAutocomplete(
-      this.site.hashtag_configurations["chat-composer"],
-      $textarea,
-      this.siteSettings,
-      {
-        treatAsTextarea: true,
-        afterComplete: (text, event) => {
-          event.preventDefault();
-          this.composer.textarea.value = text;
-          this.composer.focus();
-        },
-      }
+  #applyCategoryHashtagAutocomplete(textarea) {
+    this.applyAutocomplete(
+      textarea,
+      hashtagAutocompleteOptions(
+        this.site.hashtag_configurations["chat-composer"],
+        this.siteSettings,
+        {
+          fixedTextareaPosition: true,
+          treatAsTextarea: true,
+          afterComplete: (text, event) => {
+            event.preventDefault();
+            this.composer.textarea.value = text;
+            this.composer.focus();
+          },
+        }
+      )
     );
   }
 
-  #applyEmojiAutocomplete($textarea) {
+  #applyEmojiAutocomplete(textarea) {
     if (!this.siteSettings.enable_emoji) {
       return;
     }
 
-    $textarea.autocomplete({
-      template: findRawTemplate("emoji-selector-autocomplete"),
+    this.applyAutocomplete(textarea, {
+      template: renderEmojiAutocomplete,
       key: ":",
       afterComplete: (text, event) => {
         event.preventDefault();
@@ -476,6 +490,7 @@ export default class ChatComposer extends Component {
         this.composer.focus();
       },
       treatAsTextarea: true,
+      fixedTextareaPosition: true,
       onKeyUp: (text, cp) => {
         const matches =
           /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
@@ -490,8 +505,6 @@ export default class ChatComposer extends Component {
         if (v.code) {
           return `${v.code}:`;
         } else {
-          $textarea.autocomplete({ cancel: true });
-
           const menuOptions = {
             identifier: "emoji-picker",
             groupIdentifier: "emoji-picker",

--- a/plugin.rb
+++ b/plugin.rb
@@ -3,7 +3,7 @@
 # name: chat
 # about: Adds chat functionality to your site so it can natively support both long-form and short-form communication needs of your online community. (forked from 0.4.0)
 # meta_topic_id: 230881
-# version: 0.4.4f
+# version: 0.4.5f
 # authors: Kane York, Mark VanLandingham, Martin Brennan, Joffrey Jaffeux, fork work by Robert Barrow
 # url: https://github.com/discourse/discourse/tree/main/plugins/chat
 # meta_topic_id: 230881


### PR DESCRIPTION
Follows up the removal of raw templates (https://github.com/discourse/discourse/pull/32081) and using a new way to apply autocomplete functionality without requiring global jQuery (https://github.com/discourse/discourse/pull/33980). 

I'm unsure if you are running this on older versions of discourse, since the raw template functions should have been failing by now. Please feel free to add a `.discourse-compatibility` file to ensure appropriate version pinning so these changes don't break pre-exisiting older instances of discourse using this plugin.